### PR TITLE
ros nav stack fix dep

### DIFF
--- a/smb_navigation/package.xml
+++ b/smb_navigation/package.xml
@@ -15,7 +15,7 @@
   <depend>pointcloud_to_laserscan</depend>
   <depend>robot_self_filter</depend>
   <depend>smb_ompl_planner</depend>
-
+  <exec_depend>point_cloud_processor</exec_depend>
   <export>
   </export>
 </package>

--- a/smb_ompl_planner/CMakeLists.txt
+++ b/smb_ompl_planner/CMakeLists.txt
@@ -38,6 +38,7 @@ catkin_package(
 include_directories(
     include
     ${catkin_INCLUDE_DIRS}
+    ${OMPL_INCLUDE_DIRS}
 )
 
 add_library(${PROJECT_NAME}


### PR DESCRIPTION
Two tiny fixes:
- smb_navigation: adding execution dependency on point_cloud_processor (RSL package)
- smb_ompl_planner: adding ${OMPL_INCLUDE_DIRS} to include_directories directive (doesn't compile otherwise on my machine...)