### PR TITLE
Tuned exploration params

### DIFF
--- a/smb_navigation/config/base_local_planner.yaml
+++ b/smb_navigation/config/base_local_planner.yaml
@@ -20,19 +20,19 @@ TebLocalPlannerROS:
   global_plan_viapoint_sep: 0.5
 
   # Robot
-  max_vel_x: 1.0
+  max_vel_x: 1.5
   max_vel_y: 0.0
-  max_vel_x_backwards: 1.0
-  max_vel_y_backwards: 1.0
-  max_vel_theta: 1.0
-  acc_lim_x: 4.0
+  max_vel_x_backwards: 1.5
+  max_vel_y_backwards: 0.0
+  max_vel_theta: 1.5
+  acc_lim_x: 1.5
   acc_lim_y: 0.0
   acc_lim_theta: 2.0
   wheelbase: 0.625
-  min_turning_radius: 1.0
+  min_turning_radius: 0.0
   footprint_model: # types: "point", "circular", "two_circles", "line", "polygon"
-    type: "circular"
-    radius: 0.75 # for type "circular"
+    type: "polygon"
+    radius: 0.4 # for type "circular"
     line_start: [-0.3, 0.0] # for type "line"
     line_end: [0.3, 0.0] # for type "line"
     front_offset: 0.2 # for type "two_circles"
@@ -42,8 +42,8 @@ TebLocalPlannerROS:
     vertices: [ [0.4, 0.4], [0.4, -0.4], [-0.4, -0.4], [-0.4, 0.4] ] # for type "polygon"
 
   # GoalTolerance
-  xy_goal_tolerance: 0.3
-  yaw_goal_tolerance: 0.3
+  xy_goal_tolerance: 0.4
+  yaw_goal_tolerance: 0.4
   free_goal_vel: false
   complete_global_plan: false
 
@@ -73,7 +73,7 @@ TebLocalPlannerROS:
   weight_optimaltime: 25.0
   weight_shortest_path: 1.0
   weight_obstacle: 1
-  weight_viapoint: 5.0 # Increase to stick closer to global plan
+  weight_viapoint: 2.0 # Increase to stick closer to global plan
   weight_dynamic_obstacle: 10 # not in use yet
   selection_alternative_time_cost: False # not in use yet
 

--- a/smb_navigation/config/base_local_planner.yaml
+++ b/smb_navigation/config/base_local_planner.yaml
@@ -39,7 +39,7 @@ TebLocalPlannerROS:
     front_radius: 0.2 # for type "two_circles"
     rear_offset: 0.2 # for type "two_circles"
     rear_radius: 0.2 # for type "two_circles"
-    vertices: [ [0.4, 0.4], [0.4, -0.4], [-0.4, -0.4], [-0.4, 0.4] ] # for type "polygon"
+    vertices: [[0.43, 0.43], [0.43, -0.43], [-0.43, -0.43], [-0.43, 0.43]] # for type "polygon"
 
   # GoalTolerance
   xy_goal_tolerance: 0.4

--- a/smb_navigation/config/base_local_planner_exploration.yaml
+++ b/smb_navigation/config/base_local_planner_exploration.yaml
@@ -20,14 +20,14 @@ TebLocalPlannerROS:
   global_plan_viapoint_sep: 0.5
 
   # Robot
-  max_vel_x: 1.0
+  max_vel_x: 0.75
   max_vel_y: 0.0
-  max_vel_x_backwards: 1.0
+  max_vel_x_backwards: 0.75
   max_vel_y_backwards: 0.0
-  max_vel_theta: 1.5
-  acc_lim_x: 1.5
+  max_vel_theta: 1.0
+  acc_lim_x: 1.0
   acc_lim_y: 0.0
-  acc_lim_theta: 1.5
+  acc_lim_theta: 1.0
   
   use_proportional_saturation: true
   
@@ -46,7 +46,7 @@ TebLocalPlannerROS:
 
   # GoalTolerance
   xy_goal_tolerance: 0.5
-  yaw_goal_tolerance: 0.2
+  yaw_goal_tolerance: 0.5
   free_goal_vel: false
   complete_global_plan: false
 

--- a/smb_navigation/config/move_base_costmaps/costmap_common_params.yaml
+++ b/smb_navigation/config/move_base_costmaps/costmap_common_params.yaml
@@ -3,9 +3,6 @@
 obstacle_range: 20       # obstacles put in map up to obstacle_range
 raytrace_range: 25       # raytrace free space up to raytrace_range
 
-# footprint: [[0.4, 0.33], [0.4, -0.33], [-0.4, -0.33], [-0.4, 0.33]]  # footprint fo the robot, centered in robot centre 
-# Above param shifted to individual config files
-
 lethal_cost_threshold: 100 # which value is a deadly obstacle
 
 observation_sources: laser_scan_sensor 

--- a/smb_navigation/config/move_base_costmaps/costmap_common_params.yaml
+++ b/smb_navigation/config/move_base_costmaps/costmap_common_params.yaml
@@ -3,11 +3,10 @@
 obstacle_range: 20       # obstacles put in map up to obstacle_range
 raytrace_range: 25       # raytrace free space up to raytrace_range
 
-footprint: [[0.4, 0.4], [0.4, -0.4], [-0.4, -0.4], [-0.4, 0.4]]  # footprint fo the robot, centered in robot centre
-#robot_radius: ir_of_robot
+# footprint: [[0.4, 0.33], [0.4, -0.33], [-0.4, -0.33], [-0.4, 0.33]]  # footprint fo the robot, centered in robot centre 
+# Above param shifted to individual config files
 
-cost_scaling_factor: 1.0
-lethal_cost_threshold: 70 # which value is a deadly obstacle
+lethal_cost_threshold: 100 # which value is a deadly obstacle
 
 observation_sources: laser_scan_sensor 
 

--- a/smb_navigation/config/move_base_costmaps/global_costmap_params.yaml
+++ b/smb_navigation/config/move_base_costmaps/global_costmap_params.yaml
@@ -7,7 +7,7 @@ global_costmap:
   
   rolling_window: true
   resolution: 0.05
-  footprint: [[0.4, 0.4], [0.4, -0.4], [-0.4, -0.4], [-0.4, 0.4]]  # footprint fo the robot, centered in robot centre
+  footprint: [[0.43, 0.43], [0.43, -0.43], [-0.43, -0.43], [-0.43, 0.43]]  # footprint fo the robot, centered in robot centre
   # robot_radius: 0.4 # Just use radius now instead of footprint (To speedup collision checking)
   
   width: 100.0

--- a/smb_navigation/config/move_base_costmaps/global_costmap_params_exploration.yaml
+++ b/smb_navigation/config/move_base_costmaps/global_costmap_params_exploration.yaml
@@ -1,8 +1,8 @@
 # more on http://wiki.ros.org/navigation/Tutorials/RobotSetup
 
 global_costmap:
-  update_frequency: 5.0
-  publish_frequency: 2.0
+  update_frequency: 1.0
+  publish_frequency: 1.0
   transform_tolerance: 0.5 # [s]
   
   rolling_window: true
@@ -10,10 +10,13 @@ global_costmap:
   footprint: [[0.4, 0.4], [0.4, -0.4], [-0.4, -0.4], [-0.4, 0.4]]  # footprint fo the robot, centered in robot centre
   # robot_radius: 0.4 # Just use radius now instead of footprint (To speedup collision checking)
   
-  width: 100.0
-  height: 100.0
+  width: 30.0
+  height: 30.0
 
   plugins:
+    - 
+     name: static_layer
+     type: "costmap_2d::StaticLayer" 
     - 
      name: obstacle_layer
      type: "costmap_2d::ObstacleLayer"  
@@ -21,12 +24,14 @@ global_costmap:
      name: inflation_layer
      type: "costmap_2d::InflationLayer"
 
+
   virtual_obstacles:
     observation_sources: laser_scan_sensor
     
   obstacle_layer:
     enabled: true
-    observation_sources: laser_scan_sensor 
+    observation_sources: laser_scan_sensor
+    combination_method: 2
     laser_scan_sensor:
       data_type: 'LaserScan'
       topic: scan
@@ -40,5 +45,9 @@ global_costmap:
   inflation_layer:
     enabled: true
     observation_sources: laser_scan_sensor
-    inflation_radius: 0.4
     cost_scaling_factor: 1.0
+    inflation_radius: 0.4
+
+  static_layer:
+    map_topic: /map
+    subscribe_to_updates: true

--- a/smb_navigation/config/move_base_costmaps/global_costmap_params_exploration.yaml
+++ b/smb_navigation/config/move_base_costmaps/global_costmap_params_exploration.yaml
@@ -7,7 +7,7 @@ global_costmap:
   
   rolling_window: true
   resolution: 0.05
-  footprint: [[0.4, 0.4], [0.4, -0.4], [-0.4, -0.4], [-0.4, 0.4]]  # footprint fo the robot, centered in robot centre
+  footprint: [[0.43, 0.43], [0.43, -0.43], [-0.43, -0.43], [-0.43, 0.43]]  # footprint fo the robot, centered in robot centre
   # robot_radius: 0.4 # Just use radius now instead of footprint (To speedup collision checking)
   
   width: 30.0

--- a/smb_navigation/config/move_base_costmaps/global_costmap_params_global_map.yaml
+++ b/smb_navigation/config/move_base_costmaps/global_costmap_params_global_map.yaml
@@ -7,6 +7,7 @@ global_costmap:
   
   rolling_window: true
   resolution: 0.20
+  footprint: [[0.43, 0.43], [0.43, -0.43], [-0.43, -0.43], [-0.43, 0.43]]  # footprint fo the robot, centered in robot centre
   inflation_radius: 0.50
   
   width: 200.0

--- a/smb_navigation/config/move_base_costmaps/global_costmap_params_global_map.yaml
+++ b/smb_navigation/config/move_base_costmaps/global_costmap_params_global_map.yaml
@@ -42,4 +42,5 @@ global_costmap:
   inflation_layer:
     enabled: false
     observation_sources: laser_scan_sensor
+    cost_scaling_factor: 1.0
 

--- a/smb_navigation/config/move_base_costmaps/local_costmap_params.yaml
+++ b/smb_navigation/config/move_base_costmaps/local_costmap_params.yaml
@@ -4,7 +4,7 @@ local_costmap:
   update_frequency: 10.0
   publish_frequency: 2.0
   transform_tolerance: 0.5 # [s]
-  footprint: [[0.4, 0.4], [0.4, -0.4], [-0.4, -0.4], [-0.4, 0.4]]  # footprint fo the robot, centered in robot centre
+  footprint: [[0.43, 0.43], [0.43, -0.43], [-0.43, -0.43], [-0.43, 0.43]]  # footprint fo the robot, centered in robot centre
   # robot_radius: 0.4 # Just use radius now instead of footprint (To speedup collision checking)
 
   rolling_window: true

--- a/smb_navigation/config/move_base_costmaps/local_costmap_params.yaml
+++ b/smb_navigation/config/move_base_costmaps/local_costmap_params.yaml
@@ -4,11 +4,13 @@ local_costmap:
   update_frequency: 10.0
   publish_frequency: 2.0
   transform_tolerance: 0.5 # [s]
-  
+  footprint: [[0.4, 0.4], [0.4, -0.4], [-0.4, -0.4], [-0.4, 0.4]]  # footprint fo the robot, centered in robot centre
+  # robot_radius: 0.4 # Just use radius now instead of footprint (To speedup collision checking)
+
   rolling_window: true
   width: 8.0
   height: 8.0
-  resolution: 0.10
+  resolution: 0.05
   
   plugins:
     - 
@@ -37,4 +39,5 @@ local_costmap:
   inflation_layer:
     enabled: true
     observation_sources: laser_scan_sensor
-    inflation_radius: 0.15
+    inflation_radius: 0.4
+    cost_scaling_factor: 1.0

--- a/smb_navigation/config/ompl_global_planner.yaml
+++ b/smb_navigation/config/ompl_global_planner.yaml
@@ -10,7 +10,7 @@ OmplPlanner:
   goal_bias: 0.05              # [-] Bias in the sampling - with this probability we will sample the goal position
   tree_range: 1.5              # [m] Increase this to have longer branches in the RRT path (influence on the runtime. It represents the maximum length of a motion to be added in the tree of motions)
   interpolation_factor: 0.05   # [m] Factor for collision checking between two sampled poses
-  num_seconds_to_plan: 10.0    # [s] Planning budget
+  num_seconds_to_plan: 5.0    # [s] Planning budget
   min_distance_waypoints: 0.1  # [m] Interpolation factor of the raw global path between nodes
   dist_goal_reached: 0.3       # [m] Threshold to consider the goal reached
 

--- a/smb_navigation/launch/navigate2d_ompl.launch
+++ b/smb_navigation/launch/navigate2d_ompl.launch
@@ -9,6 +9,10 @@
   <arg name="use_global_map"
        default="false"
        doc="whether to use predefined map for global planning"/>
+
+  <arg name="exploration"
+       default="false"
+       doc="whether to use parameters for exploration"/>
   
   <arg name="run_traversability"
        default="false"
@@ -77,6 +81,7 @@
       
       <arg name="sim"               value="$(arg sim)"/>
       <arg name="use_global_map"    value="$(arg use_global_map)"/>
+      <arg name="exploration"       value="$(arg exploration)"/>
     </include>
     
     <!-- Run the map server -->

--- a/smb_ompl_planner/launch/move_base_ompl.launch
+++ b/smb_ompl_planner/launch/move_base_ompl.launch
@@ -5,6 +5,7 @@
   <arg name="launch_prefix"         default=""/>
   <arg name="sim"                   default="false"/>
   <arg name="use_global_map"        default="false"/>
+  <arg name="exploration"           default="false"/>
 
   <arg name="cmd_vel_topic"         default="/control/teb_planner_twist"/>
   <arg name="tf_topic"              default="/tf"/>
@@ -18,10 +19,12 @@
   <arg name="base_local_planner"    default="teb_local_planner/TebLocalPlannerROS"/>
   
   <!-- Argument to swap between config files (sim or real robot) -->
+  <!-- This arg is ignored in case of exploration-->
   <arg name="config_file_suffix"    value="_sim" if="$(arg sim)"/>
   <arg name="config_file_suffix"    value=""     unless="$(arg sim)"/>
   
   <!-- Argument to swap between config files (use global static map or not) -->
+  <!-- This arg is ignored in case of exploration-->
   <arg name="global_map_suffix"     value="_global_map" if="$(arg use_global_map)"/>
   <arg name="global_map_suffix"     value=""            unless="$(arg use_global_map)"/>
 
@@ -40,8 +43,9 @@
     <!-- Load the OMPL parameters -->
     <rosparam file="$(find smb_navigation)/config/ompl_global_planner.yaml" command="load"/>
     
-    <!-- Load the right config file for local planner (suffix is either "" or "_sim") -->
-    <rosparam file="$(find smb_navigation)/config/base_local_planner$(arg config_file_suffix).yaml" command="load"/>
+    <!-- Load the right config file for local planner (suffix is either "" or "_sim" or "exploration") -->
+    <rosparam file="$(find smb_navigation)/config/base_local_planner_exploration.yaml" command="load" if="$(arg exploration)"/>
+    <rosparam file="$(find smb_navigation)/config/base_local_planner$(arg config_file_suffix).yaml" command="load" unless="$(arg exploration)"/>
     
     <!-- Additional parameters -->
     <param name="footprint_padding"         value="0.01" />
@@ -65,8 +69,9 @@
     <param name="TebLocalPlannerROS/odom_topic"   value="$(arg odom_topic)"/>
     <param name="TebLocalPlannerROS/map_frame"    value="$(arg global_frame)"/> <!-- This is the global planning frame -->
 
-    <!-- global costmap -->
-    <rosparam file="$(find smb_navigation)/config/move_base_costmaps/global_costmap_params$(arg global_map_suffix).yaml" command="load"/>    
+    <!-- global costmap (param file suffix is either "" or "_sim" or "exploration") -->
+    <rosparam file="$(find smb_navigation)/config/move_base_costmaps/global_costmap_params_exploration.yaml" command="load" if="$(arg exploration)"/>
+    <rosparam file="$(find smb_navigation)/config/move_base_costmaps/global_costmap_params$(arg global_map_suffix).yaml" command="load" unless="$(arg exploration)"/>    
     <param name="global_costmap/global_frame"     value="$(arg global_frame)"/>
     <param name="global_costmap/robot_base_frame" value="$(arg robot_base_frame)"/>
     


### PR DESCRIPTION
This PR adds parameter files for running frontier-based exploration (explore lite)

Just set the argument ```exploration=true``` while launching the navigate_2d_ompl launch file and it will load the config files tuned for exploration.

Apart from that, some general parameters are tuned. Further, tuning will be required for the outdoor scenarios